### PR TITLE
Waypoint: Using typeof    wording suggest

### DIFF
--- a/seed/challenges/automated-testing-and-debugging.json
+++ b/seed/challenges/automated-testing-and-debugging.json
@@ -39,7 +39,7 @@
       "tests":[
         "assert(editor.getValue().match(/console\\.log\\(typeof\\(\"\"\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a string.');",
         "assert(editor.getValue().match(/console\\.log\\(typeof\\(0\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a number.');",
-        "assert(editor.getValue().match(/console\\.log\\(typeof\\(\\[\\]\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> an array.');",
+        "assert(editor.getValue().match(/console\\.log\\(typeof\\(\\[\\]\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a object. But JavaScript arrays are best described as arrays.');",
         "assert(editor.getValue().match(/console\\.log\\(typeof\\(\\{\\}\\)\\);/gi), 'You should <code>console.log</code> the <code>typeof</code> a object.');"
       ],
       "challengeSeed":[


### PR DESCRIPTION
Chrome and Firefox console all show the answer as **object** instead of **array**
w3school and stackoverflow confirm this.

it's mentioned in the description, but I feel maybe it's better to point it out under the test check, because some people may get confused when they see the output is not the same as it says.